### PR TITLE
Fix ir copy in fallback

### DIFF
--- a/numba/dppl/tests/dppl/test_parfor_lower_message.py
+++ b/numba/dppl/tests/dppl/test_parfor_lower_message.py
@@ -3,28 +3,30 @@ import numba
 from numba import dppl, njit, prange
 from numba.dppl.testing import unittest, DPPLTestCase
 from numba.tests.support import captured_stdout
-import dpctl
+import dpctl.ocldrv as ocldrv
 
 
 def prange_example():
     n = 10
-    a = np.ones((n, n), dtype=np.float64)
-    b = np.ones((n, n), dtype=np.float64)
-    c = np.ones((n, n), dtype=np.float64)
-    for i in prange(n):
+    a = np.ones((n), dtype=np.float64)
+    b = np.ones((n), dtype=np.float64)
+    c = np.ones((n), dtype=np.float64)
+    for i in prange(n//2):
         a[i] = b[i] + c[i]
 
+    return a
 
-@unittest.skipUnless(dpctl.has_gpu_queues(), 'test only on GPU system')
+
+@unittest.skipUnless(ocldrv.has_gpu_device, 'test only on GPU system')
 class TestParforMessage(DPPLTestCase):
     def test_parfor_message(self):
         numba.dppl.compiler.DEBUG = 1
         jitted = njit(parallel={'offload':True})(prange_example)
 
         with captured_stdout() as got:
-            with dpctl.device_context("opencl:gpu") as gpu_queue:
-                jitted()
+            jitted()
 
+        numba.dppl.compiler.DEBUG = 0
         self.assertTrue('Parfor lowered on DPPL-device' in got.getvalue())
 
 


### PR DESCRIPTION
Some IR objects can't be deep-copied. This results running some parfors on CPU even if they can be ran on GPU.