### PR TITLE
Add check if dpctl is present in decorator

### DIFF
--- a/numba/core/decorators.py
+++ b/numba/core/decorators.py
@@ -221,8 +221,10 @@ def _jit(sigs, locals, target, cache, targetoptions, **dispatcher_args):
                 f"{type(func)})."
             )
 
+        from numba import dppl_config
         if (target == 'npyufunc' or targetoptions.get('no_cpython_wrapper')
-            or sigs or config.DISABLE_JIT or not targetoptions.get('nopython')):
+            or sigs or config.DISABLE_JIT or not targetoptions.get('nopython')
+            or dppl_config.dppl_present is not True):
             target_ = target
             if target_ is None:
                 target_ = 'cpu'

--- a/numba/core/dispatcher.py
+++ b/numba/core/dispatcher.py
@@ -906,6 +906,9 @@ class Dispatcher(serialize.ReduceMixin, _MemoMixin, _DispatcherBase, metaclass=D
             cres = tuple(self.overloads.values())[0]
             return types.FunctionType(cres.signature)
 
+    def get_compiled(self):
+        return self
+
 
 class LiftedCode(serialize.ReduceMixin, _MemoMixin, _DispatcherBase):
     """

--- a/numba/dppl/tests/dppl/test_with_context.py
+++ b/numba/dppl/tests/dppl/test_with_context.py
@@ -29,11 +29,11 @@ class TestWithDPPLContext(DPPLTestCase):
             with dpctl.device_context("opencl:gpu"):
                 func(got_gpu)
 
+        numba.dppl.compiler.DEBUG = 0
         func(expected)
 
         np.testing.assert_array_equal(expected, got_gpu)
         self.assertTrue('Parfor lowered on DPPL-device' in got_gpu_message.getvalue())
-        numba.dppl.compiler.DEBUG = 0
 
     @unittest.skipIf(not dpctl.has_cpu_queues(), "No CPU platforms available")
     def test_with_dppl_context_cpu(self):
@@ -55,11 +55,11 @@ class TestWithDPPLContext(DPPLTestCase):
             with dpctl.device_context("opencl:cpu"):
                 func(got_cpu)
 
+        numba.dppl.compiler.DEBUG = 0
         func(expected)
 
         np.testing.assert_array_equal(expected, got_cpu)
         self.assertTrue('Parfor lowered on DPPL-device' in got_cpu_message.getvalue())
-        numba.dppl.compiler.DEBUG = 0
 
 
     @unittest.skipIf(not dpctl.has_gpu_queues(), "No GPU platforms available")


### PR DESCRIPTION
1. Check dppl_present flag in decorators
2. Add get_compiled method to dispatcher.Dispatcher.
When TargetDispatcher was added some tests were modified to call .get_compiled(). In order to make these tests not to fail similar method is added to dispatcher.Dispatcher.
3. Moved numba.dppl.compiler.DEBUG = 0 to avoid printing extra information.

No tests were added
