### PR TITLE
Patch for with context

### DIFF
--- a/numba/core/dispatcher.py
+++ b/numba/core/dispatcher.py
@@ -673,14 +673,7 @@ class _MemoMixin:
         self._recent.append(self)
 
 
-import abc
-
-class DispatcherMeta(abc.ABCMeta):
-    def __instancecheck__(self, other):
-        return type(type(other)) == DispatcherMeta
-
-
-class Dispatcher(serialize.ReduceMixin, _MemoMixin, _DispatcherBase, metaclass=DispatcherMeta):
+class Dispatcher(serialize.ReduceMixin, _MemoMixin, _DispatcherBase):
     """
     Implementation of user-facing dispatcher objects (i.e. created using
     the @jit decorator).
@@ -905,9 +898,6 @@ class Dispatcher(serialize.ReduceMixin, _MemoMixin, _DispatcherBase, metaclass=D
         if not self._can_compile and len(self.overloads) == 1:
             cres = tuple(self.overloads.values())[0]
             return types.FunctionType(cres.signature)
-
-    def get_compiled(self):
-        return self
 
 
 class LiftedCode(serialize.ReduceMixin, _MemoMixin, _DispatcherBase):

--- a/numba/core/registry.py
+++ b/numba/core/registry.py
@@ -2,7 +2,6 @@ import contextlib
 
 from numba.core.descriptors import TargetDescriptor
 from numba.core import utils, typing, dispatcher, cpu
-from numba.core.compiler_lock import global_compiler_lock
 
 # -----------------------------------------------------------------------------
 # Default CPU target descriptors
@@ -27,19 +26,16 @@ class CPUTarget(TargetDescriptor):
     _nested = _NestedContext()
 
     @utils.cached_property
-    @global_compiler_lock
     def _toplevel_target_context(self):
         # Lazily-initialized top-level target context, for all threads
         return cpu.CPUContext(self.typing_context)
 
     @utils.cached_property
-    @global_compiler_lock
     def _toplevel_typing_context(self):
         # Lazily-initialized top-level typing context, for all threads
         return typing.Context()
 
     @property
-    @global_compiler_lock
     def target_context(self):
         """
         The target context for CPU targets.
@@ -51,7 +47,6 @@ class CPUTarget(TargetDescriptor):
             return self._toplevel_target_context
 
     @property
-    @global_compiler_lock
     def typing_context(self):
         """
         The typing context for CPU targets.
@@ -62,7 +57,6 @@ class CPUTarget(TargetDescriptor):
         else:
             return self._toplevel_typing_context
 
-    @global_compiler_lock
     def nested_context(self, typing_context, target_context):
         """
         A context manager temporarily replacing the contexts with the

--- a/numba/tests/test_dispatcher.py
+++ b/numba/tests/test_dispatcher.py
@@ -398,8 +398,6 @@ class TestDispatcher(BaseTest):
         def foo(x):
             return x + 1
 
-        foo = foo.get_compiled()
-
         self.assertEqual(foo(1), 2)
 
         # get serialization memo

--- a/numba/tests/test_nrt.py
+++ b/numba/tests/test_nrt.py
@@ -249,8 +249,6 @@ class TestTracemalloc(unittest.TestCase):
             """
             return np.empty(N, dtype)
 
-        alloc_nrt_memory = alloc_nrt_memory.get_compiled()
-
         def keep_memory():
             return alloc_nrt_memory()
 

--- a/numba/tests/test_record_dtype.py
+++ b/numba/tests/test_record_dtype.py
@@ -803,8 +803,8 @@ class TestRecordDtype(unittest.TestCase):
         self.assertIn('Array', transformed)
         self.assertNotIn('first', transformed)
         self.assertNotIn('second', transformed)
-        # Length is usually 60 - 5 chars tolerance as above.
-        self.assertLess(len(transformed), 60)
+        # Length is usually 50 - 5 chars tolerance as above.
+        self.assertLess(len(transformed), 50)
 
     def test_record_two_arrays(self):
         """

--- a/numba/tests/test_serialize.py
+++ b/numba/tests/test_serialize.py
@@ -135,9 +135,9 @@ class TestDispatcherPickling(TestCase):
 
         Note that "same function" is intentionally under-specified.
         """
-        func = closure(5).get_compiled()
+        func = closure(5)
         pickled = pickle.dumps(func)
-        func2 = closure(6).get_compiled()
+        func2 = closure(6)
         pickled2 = pickle.dumps(func2)
 
         f = pickle.loads(pickled)
@@ -152,7 +152,7 @@ class TestDispatcherPickling(TestCase):
         self.assertEqual(h(2, 3), 11)
 
         # Now make sure the original object doesn't exist when deserializing
-        func = closure(7).get_compiled()
+        func = closure(7)
         func(42, 43)
         pickled = pickle.dumps(func)
         del func


### PR DESCRIPTION
This modifications make jit() decorator use TargetDispatcher from dppl.
Changes made in #57 by @AlexanderKalistratov and @1e-to.

This PR is for discussion about refactoring this modifications into Numba extension.