### PR TITLE
Patch for lowering

### DIFF
--- a/numba/core/lowering.py
+++ b/numba/core/lowering.py
@@ -279,13 +279,6 @@ lower_extensions = {}
 class Lower(BaseLower):
     GeneratorLower = generators.GeneratorLower
 
-    def __init__(self, context, library, fndesc, func_ir, metadata=None):
-        BaseLower.__init__(self, context, library, fndesc, func_ir, metadata)
-        from numba.parfors.parfor_lowering import _lower_parfor_parallel
-        from numba.parfors import parfor
-        if parfor.Parfor not in lower_extensions:
-            lower_extensions[parfor.Parfor] = [_lower_parfor_parallel]
-
     def pre_block(self, block):
         from numba.core.unsafe import eh
 
@@ -452,7 +445,7 @@ class Lower(BaseLower):
         else:
             for _class, func in lower_extensions.items():
                 if isinstance(inst, _class):
-                    func[-1](self, inst)
+                    func(self, inst)
                     return
             raise NotImplementedError(type(inst))
 

--- a/numba/parfors/parfor_lowering.py
+++ b/numba/parfors/parfor_lowering.py
@@ -480,7 +480,7 @@ def _lower_parfor_parallel(lowerer, parfor):
         print("_lower_parfor_parallel done")
 
 # A work-around to prevent circular imports
-#lowering.lower_extensions[parfor.Parfor] = _lower_parfor_parallel
+lowering.lower_extensions[parfor.Parfor] = _lower_parfor_parallel
 
 
 def _create_shape_signature(


### PR DESCRIPTION
This change removes global initialization of lower_extensions
with one functions and replaces with a list of functions.
This change made in commit 947b407 by @reazulhoque.

@AlexanderKalistratov have thoughts to remove this code because with TargetDispatcher it is not effective.