### PR TITLE
Uncomment require_global_compiler_lock()

### DIFF
--- a/numba/core/codegen.py
+++ b/numba/core/codegen.py
@@ -220,7 +220,7 @@ class CodeLibrary(object):
         Finalization involves various stages of code optimization and
         linking.
         """
-        #require_global_compiler_lock()
+        require_global_compiler_lock()
 
         # Report any LLVM-related problems to the user
         self._codegen._check_llvm_bugs()


### PR DESCRIPTION
This line was commented when introduced codegen debugging by @DrTodd13.
Uncommenting this line requires modifications in numba-dppy.
It seems that numba-dppy compilation does not work correctly with
global compiler lock.