### PR TITLE
Pipeline control flow

### DIFF
--- a/mlir-compiler/CMakeLists.txt
+++ b/mlir-compiler/CMakeLists.txt
@@ -28,6 +28,7 @@ set(SOURCES_LIST
     src/rewrites/cast_lowering.cpp
     src/rewrites/type_conversion.cpp
     src/transforms/loop_utils.cpp
+    src/transforms/pipeline_utils.cpp
     src/compiler.cpp
     src/dialect.cpp
     src/lowering.cpp
@@ -46,6 +47,7 @@ set(HEADERS_LIST
     src/rewrites/cast_lowering.hpp
     src/rewrites/type_conversion.hpp
     src/transforms/loop_utils.hpp
+    src/transforms/pipeline_utils.hpp
     src/compiler.hpp
     src/lowering.hpp
     src/pipeline_registry.hpp

--- a/mlir-compiler/src/compiler.cpp
+++ b/mlir-compiler/src/compiler.cpp
@@ -9,16 +9,20 @@
 
 #include <llvm/Support/raw_ostream.h>
 
+#include <unordered_map>
+
 #include "utils.hpp"
 
 #include "pipeline_registry.hpp"
 
-class CompilerContext::CompilerContextImpl
+namespace
 {
-public:
-    CompilerContextImpl(mlir::MLIRContext& ctx,
-                        const CompilerContext::Settings& settings,
-                        const PipelineRegistry& registry):
+struct PassManagerStage
+{
+    template<typename F>
+    PassManagerStage(mlir::MLIRContext& ctx,
+                     const CompilerContext::Settings& settings,
+                     F&& init_func):
         pm(&ctx)
     {
         pm.enableVerifier(settings.verify);
@@ -37,10 +41,142 @@ public:
             pm.enableIRPrinting();
         }
 
-        registry.populate_pass_manager(pm);
+        init_func(pm);
     }
 
-    void run(mlir::ModuleOp& module)
+    void add_jump(mlir::StringAttr name, PassManagerStage* stage)
+    {
+        assert(!name.getValue().empty());
+        assert(nullptr != stage);
+        jumps.emplace_back(name, stage);
+    }
+
+    PassManagerStage* get_jump(mlir::ArrayAttr names) const
+    {
+        for (auto& it : jumps)
+        {
+            for (auto name : names)
+            {
+                if (it.first == name.cast<mlir::StringAttr>())
+                {
+                    return it.second;
+                }
+            }
+        }
+        return nullptr;
+    }
+
+    void set_next_stage(PassManagerStage* stage)
+    {
+        assert(nullptr == next_stage);
+        assert(nullptr != stage);
+        next_stage = stage;
+    }
+
+    PassManagerStage* get_next_sgate() const
+    {
+        return next_stage;
+    }
+
+    mlir::LogicalResult run(mlir::ModuleOp op)
+    {
+        return pm.run(op);
+    }
+
+private:
+    mlir::PassManager pm;
+    llvm::SmallVector<std::pair<mlir::StringAttr, PassManagerStage*>, 1> jumps;
+    PassManagerStage* next_stage = nullptr;
+};
+
+struct PassManagerSchedule
+{
+    PassManagerSchedule(mlir::MLIRContext& ctx,
+                        const CompilerContext::Settings& settings,
+                        const PipelineRegistry& registry)
+    {
+        auto func = [&](auto sink)
+        {
+            struct StageDesc
+            {
+                llvm::StringRef name;
+                llvm::ArrayRef<llvm::StringRef> jumps;
+                std::unique_ptr<PassManagerStage> stage;
+            };
+
+            assert(nullptr == stages);
+            llvm::SmallVector<StageDesc, 64> stages_temp;
+            std::unordered_map<const void*, PassManagerStage*> stages_map;
+
+            auto add_stage = [&](llvm::StringRef name, llvm::ArrayRef<llvm::StringRef> jumps, auto pm_init_func)
+            {
+                assert(!name.empty());
+                auto prev_stage = (stages_map.empty() ? nullptr : stages_temp.back().stage.get());
+                stages_temp.push_back({name, jumps, std::make_unique<PassManagerStage>(ctx, settings, pm_init_func)});
+                assert(stages_map.count(name.data()) == 0);
+                stages_map.insert({name.data(), stages_temp.back().stage.get()});
+                if (nullptr != prev_stage)
+                {
+                    prev_stage->set_next_stage(stages_temp.back().stage.get());
+                }
+            };
+
+            sink(add_stage);
+
+            for (auto& stage : stages_temp)
+            {
+                for (auto jump : stage.jumps)
+                {
+                    assert(!jump.empty());
+                    auto it = stages_map.find(jump.data());
+                    assert(it != stages_map.end());
+                    assert(nullptr != it->second);
+                    auto name = mlir::StringAttr::get(jump, &ctx);
+                    stage.stage->add_jump(name, it->second);
+                }
+            }
+
+            stages = std::make_unique<std::unique_ptr<PassManagerStage>[]>(stages_temp.size());
+            for (auto it : llvm::enumerate(stages_temp))
+            {
+                stages[it.index()] = std::move(it.value().stage);
+            }
+        };
+        registry.populate_pass_manager(func);
+    }
+
+    mlir::LogicalResult run(mlir::ModuleOp module)
+    {
+        assert(nullptr != stages);
+        auto current = stages[0].get();
+        do
+        {
+            assert(nullptr != current);
+            if (mlir::failed(current->run(module)))
+            {
+                return mlir::failure();
+            }
+            // TODO: jumps
+            current = current->get_next_sgate();
+        }
+        while (nullptr != current);
+        return mlir::success();
+    }
+
+private:
+    std::unique_ptr<std::unique_ptr<PassManagerStage>[]> stages;
+};
+}
+
+class CompilerContext::CompilerContextImpl
+{
+public:
+    CompilerContextImpl(mlir::MLIRContext& ctx,
+                        const CompilerContext::Settings& settings,
+                        const PipelineRegistry& registry):
+        schedule(ctx, settings, registry) {}
+
+    void run(mlir::ModuleOp module)
     {
         std::string err;
         llvm::raw_string_ostream err_stream(err);
@@ -52,9 +188,9 @@ public:
             }
         };
 
-        scoped_diag_handler(*pm.getContext(), diag_handler, [&]()
+        scoped_diag_handler(*module.getContext(), diag_handler, [&]()
         {
-            if (mlir::failed(pm.run(module)))
+            if (mlir::failed(schedule.run(module)))
             {
                 err_stream << "\n";
                 module.print(err_stream);
@@ -64,7 +200,7 @@ public:
         });
     }
 private:
-    mlir::PassManager pm;
+    PassManagerSchedule schedule;
 };
 
 CompilerContext::CompilerContext(mlir::MLIRContext& ctx,

--- a/mlir-compiler/src/pipeline_registry.cpp
+++ b/mlir-compiler/src/pipeline_registry.cpp
@@ -90,6 +90,7 @@ void PipelineRegistry::populate_pass_manager(mlir::OpPassManager& pm) const
     auto sink = [&](llvm::StringRef pipeline_name,
                     llvm::ArrayRef<llvm::StringRef> prev_pipelines,
                     llvm::ArrayRef<llvm::StringRef> next_pipelines,
+                    llvm::ArrayRef<llvm::StringRef> jumps,
                     pipeline_funt_t func)
     {
         assert(!pipeline_name.empty());

--- a/mlir-compiler/src/pipeline_registry.cpp
+++ b/mlir-compiler/src/pipeline_registry.cpp
@@ -178,9 +178,17 @@ void PipelineRegistry::populate_pass_manager(mlir::OpPassManager& pm) const
         topo_visit(get_pipeline_info(name), iter_func, visit_func);
     }
 
-    for (auto current = first_pipeline; nullptr != current;
-         current = current->next)
-     {
-        current->func(pm);
-     }
+    auto iterate_pipelines = [&](auto func)
+    {
+        for (auto current = first_pipeline; nullptr != current;
+             current = current->next)
+        {
+            func(current);
+        }
+    };
+
+    iterate_pipelines([&](PipelineInfo* pipeline)
+    {
+        pipeline->func(pm);
+    });
 }

--- a/mlir-compiler/src/pipeline_registry.hpp
+++ b/mlir-compiler/src/pipeline_registry.hpp
@@ -30,7 +30,10 @@ public:
 
     void register_pipeline(registry_entry_t func);
 
-    void populate_pass_manager(mlir::OpPassManager& pm) const;
+    using fill_stage_sink_t = llvm::function_ref<void(llvm::StringRef name, llvm::ArrayRef<llvm::StringRef> jumps, llvm::function_ref<void(mlir::OpPassManager&)>)>;
+    using populate_pass_manager_sink_t = llvm::function_ref<void(fill_stage_sink_t)>;
+    using populate_pass_manager_t = llvm::function_ref<void(populate_pass_manager_sink_t)>;
+    void populate_pass_manager(populate_pass_manager_t result_sink) const;
 
 private:
     std::vector<registry_entry_t> pipelines;

--- a/mlir-compiler/src/pipeline_registry.hpp
+++ b/mlir-compiler/src/pipeline_registry.hpp
@@ -24,6 +24,7 @@ public:
         llvm::StringRef pipeline_name,
         llvm::ArrayRef<llvm::StringRef> prev_pipelines,
         llvm::ArrayRef<llvm::StringRef> next_pipelines,
+        llvm::ArrayRef<llvm::StringRef> jumps,
         pipeline_funt_t func);
     using registry_entry_t = std::function<void(llvm::function_ref<registry_entry_sink_t>)>;
 

--- a/mlir-compiler/src/pipelines/base_pipeline.cpp
+++ b/mlir-compiler/src/pipelines/base_pipeline.cpp
@@ -21,11 +21,11 @@ void register_base_pipeline(PipelineRegistry& registry)
         {
             if (0 == i)
             {
-                sink(passes[i], {}, {}, dummy_pass_func);
+                sink(passes[i], {}, {}, {}, dummy_pass_func);
             }
             else
             {
-                sink(passes[i], {passes[i - 1]}, {}, dummy_pass_func);
+                sink(passes[i], {passes[i - 1]}, {}, {}, dummy_pass_func);
             }
         });
     }

--- a/mlir-compiler/src/pipelines/lower_to_llvm.cpp
+++ b/mlir-compiler/src/pipelines/lower_to_llvm.cpp
@@ -568,7 +568,7 @@ void register_lower_to_llvm_pipeline(PipelineRegistry& registry)
     registry.register_pipeline([](auto sink)
     {
         auto stage = get_lower_lowering_stage();
-        sink(lower_to_llvm_pipeline_name(), {stage.begin}, {stage.end}, &populate_lower_to_llvm_pipeline);
+        sink(lower_to_llvm_pipeline_name(), {stage.begin}, {stage.end}, {}, &populate_lower_to_llvm_pipeline);
     });
 }
 

--- a/mlir-compiler/src/pipelines/plier_to_linalg.cpp
+++ b/mlir-compiler/src/pipelines/plier_to_linalg.cpp
@@ -350,7 +350,7 @@ void register_plier_to_linalg_pipeline(PipelineRegistry& registry)
     registry.register_pipeline([](auto sink)
     {
         auto stage = get_high_lowering_stage();
-        sink(plier_to_linalg_pipeline_name(), {plier_to_std_pipeline_name()}, {stage.end}, &populate_plier_to_linalg_pipeline);
+        sink(plier_to_linalg_pipeline_name(), {plier_to_std_pipeline_name()}, {stage.end}, {}, &populate_plier_to_linalg_pipeline);
     });
 }
 

--- a/mlir-compiler/src/pipelines/plier_to_std.cpp
+++ b/mlir-compiler/src/pipelines/plier_to_std.cpp
@@ -1227,7 +1227,7 @@ void register_plier_to_std_pipeline(PipelineRegistry& registry)
     registry.register_pipeline([](auto sink)
     {
         auto stage = get_high_lowering_stage();
-        sink(plier_to_std_pipeline_name(), {stage.begin}, {stage.end}, &populate_plier_to_std_pipeline);
+        sink(plier_to_std_pipeline_name(), {stage.begin}, {stage.end}, {}, &populate_plier_to_std_pipeline);
     });
 }
 

--- a/mlir-compiler/src/pipelines/plier_to_std.cpp
+++ b/mlir-compiler/src/pipelines/plier_to_std.cpp
@@ -1134,23 +1134,11 @@ struct PlierToStdPass :
     {
         registry.insert<plier::PlierDialect>();
         registry.insert<mlir::StandardOpsDialect>();
+        registry.insert<mlir::scf::SCFDialect>();
     }
 
     void runOnOperation() override;
 };
-
-template<typename T>
-mlir::Value cast_materializer(
-    mlir::OpBuilder& builder, T type, mlir::ValueRange inputs,
-    mlir::Location loc)
-{
-    assert(inputs.size() == 1);
-    if (type == inputs[0].getType())
-    {
-        return inputs[0];
-    }
-    return builder.create<plier::CastOp>(loc, type, inputs[0]);
-}
 
 void PlierToStdPass::runOnOperation()
 {

--- a/mlir-compiler/src/transforms/pipeline_utils.cpp
+++ b/mlir-compiler/src/transforms/pipeline_utils.cpp
@@ -1,0 +1,72 @@
+#include "transforms/pipeline_utils.hpp"
+
+#include <mlir/IR/Module.h>
+#include <mlir/IR/Attributes.h>
+
+mlir::ModuleOp get_module(mlir::Operation* op)
+{
+    assert(nullptr != op);
+    while (!mlir::isa<mlir::ModuleOp>(op))
+    {
+        op = op->getParentOp();
+        assert(nullptr != op);
+    }
+    return mlir::cast<mlir::ModuleOp>(op);
+}
+
+namespace
+{
+const constexpr llvm::StringLiteral jump_marker_name("pipeline_jump_markers");
+}
+
+mlir::ArrayAttr get_pipeline_jump_markers(mlir::ModuleOp module)
+{
+    return module.getAttrOfType<mlir::ArrayAttr>(jump_marker_name);
+}
+
+void add_pipeline_jump_marker(mlir::ModuleOp module, mlir::StringAttr name)
+{
+    assert(name);
+    assert(!name.getValue().empty());
+
+    llvm::SmallVector<mlir::Attribute, 16> name_list;
+    if (auto old_attr = module.getAttrOfType<mlir::ArrayAttr>(jump_marker_name))
+    {
+        name_list.assign(old_attr.begin(), old_attr.end());
+    }
+    auto it = llvm::lower_bound(name_list, name,
+    [](mlir::Attribute lhs, mlir::StringAttr rhs)
+    {
+        return lhs.cast<mlir::StringAttr>().getValue() < rhs.getValue();
+    });
+    if (it == name_list.end())
+    {
+        name_list.emplace_back(name);
+    }
+    else if (*it != name)
+    {
+        name_list.insert(it, name);
+    }
+    module.setAttr(jump_marker_name, mlir::ArrayAttr::get(name_list, module.getContext()));
+}
+
+
+void remove_pipeline_jump_marker(mlir::ModuleOp module, mlir::StringAttr name)
+{
+    assert(name);
+    assert(!name.getValue().empty());
+
+    llvm::SmallVector<mlir::Attribute, 16> name_list;
+    if (auto old_attr = module.getAttrOfType<mlir::ArrayAttr>(jump_marker_name))
+    {
+        name_list.assign(old_attr.begin(), old_attr.end());
+    }
+    auto it = llvm::lower_bound(name_list, name,
+    [](mlir::Attribute lhs, mlir::StringAttr rhs)
+    {
+        return lhs.cast<mlir::StringAttr>().getValue() < rhs.getValue();
+    });
+    assert(it != name_list.end());
+    name_list.erase(it);
+    module.setAttr(jump_marker_name, mlir::ArrayAttr::get(name_list, module.getContext()));
+}

--- a/mlir-compiler/src/transforms/pipeline_utils.hpp
+++ b/mlir-compiler/src/transforms/pipeline_utils.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+namespace mlir
+{
+class ArrayAttr;
+class Operation;
+class ModuleOp;
+class StringAttr;
+}
+
+mlir::ModuleOp get_module(mlir::Operation* op);
+mlir::ArrayAttr get_pipeline_jump_markers(mlir::ModuleOp module);
+void add_pipeline_jump_marker(mlir::ModuleOp module, mlir::StringAttr name);
+void remove_pipeline_jump_marker(mlir::ModuleOp module, mlir::StringAttr name);


### PR DESCRIPTION
Allow control flow in compiler pipeline via special module-level markers (e.g. if you need to rerun some previous compiler stages after your stage)