### PR TITLE
Remove checking on user variable to emit all debug info

### DIFF
--- a/numba/core/lowering.py
+++ b/numba/core/lowering.py
@@ -1303,17 +1303,15 @@ class Lower(BaseLower):
         return self.alloca_lltype(name, lltype)
 
     def alloca_lltype(self, name, lltype):
-        # Is user variable?
-        is_uservar = not name.startswith('$')
         # Allocate space for variable
         aptr = cgutils.alloca_once(self.builder, lltype,
                                    name=name, zfill=False)
-        if is_uservar:
-            # Emit debug info for user variable
-            sizeof = self.context.get_abi_sizeof(lltype)
-            self.debuginfo.mark_variable(self.builder, aptr, name=name,
-                                         lltype=lltype, size=sizeof,
-                                         loc=self.loc)
+
+        # Emit debug info for all variables
+        sizeof = self.context.get_abi_sizeof(lltype)
+        self.debuginfo.mark_variable(self.builder, aptr, name=name,
+                                     lltype=lltype, size=sizeof,
+                                     loc=self.loc)
         return aptr
 
     def incref(self, typ, val):


### PR DESCRIPTION
<!--

Thanks for wanting to contribute to Numba :)

First, if you need some help or want to chat to the core developers, please
visit https://gitter.im/numba/numba for real time chat or post to the Numba
forum https://numba.discourse.group/.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label when you'd like it to be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->

This PR removes possessing "$" sign checking for emitting debug information. This checking currently may not be valid anymore due to many compiler passes are not retaining the user variable. This checking also blocks development of gdb support in numba-dppy.