### PR TITLE
Change compile unit language in DWARF to C++

### DIFF
--- a/numba/core/debuginfo.py
+++ b/numba/core/debuginfo.py
@@ -216,7 +216,7 @@ class DIBuilder(AbstractDIBuilder):
 
     def _di_compile_unit(self):
         return self.module.add_debug_info('DICompileUnit', {
-            'language': ir.DIToken('DW_LANG_Python'),
+            'language': ir.DIToken('DW_LANG_C_plus_plus'),
             'file': self.difile,
             'producer': 'Numba',
             'runtimeVersion': 0,


### PR DESCRIPTION
Change DWARF language to `DW_LANG_C_plus_plus`.
It helps GDB to understand C++ mangled functions.

@vlad-perevezentsev 